### PR TITLE
Fix meters parameter for energy and power details

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ import (
     "fmt"
     "os"
 
-    "github.com/elliott-davis/solaredge-go"
+    "github.com/elliott-davis/solaredge-go/solaredge"
 )
 
 func main() {
     token := os.Getenv("SOLAREDGE_AUTH_TOKEN")
     // You may optionally include your own http client
-    client = solaredge.NewClient(nil, token)
+    client := solaredge.NewClient(nil, token)
     site, err := client.Site.List(&solaredge.ListOptions{Page: 2, PerPage: 1})
     if err != nil {
     	panic(err)

--- a/solaredge/site-energy-details.go
+++ b/solaredge/site-energy-details.go
@@ -8,7 +8,7 @@ import (
 type SiteEnergyDetailsRequest struct {
 	StartTime DateTime `url:"startTime"`
 	EndTime DateTime `url:"endTime"`
-	Meters []Meter `url:"meter"`
+	Meters []Meter `url:"meters"`
 	TimeUnit *TimeUnit `url:"timeUnit"` // Should probably be an enum
 }
 

--- a/solaredge/site-power-details.go
+++ b/solaredge/site-power-details.go
@@ -13,7 +13,7 @@ type Meters struct {
 type SitePowerDetailsRequest struct {
 	StartTime DateTime `url:"startTime"`
 	EndTime DateTime `url:"endTime"`
-	Meters []Meter `url:"meter"`
+	Meters []Meter `url:"meters"`
 }
 
 type SitePowerDetails struct {
@@ -29,7 +29,7 @@ type SitePowerDetailsResponse struct {
 func  (s *SiteService) PowerDetails(siteId int64, request SitePowerDetailsRequest) (SitePowerDetails, error) {
 	// Ensure start and end are defined
 	if request.EndTime.IsZero() || request.StartTime.IsZero() {
-		return SitePowerDetails{}, errors.New("start and End times are required")
+		return SitePowerDetails{}, errors.New("start and end times are required")
 	}
 
 	u, err := addOptions(fmt.Sprintf("/site/%d/powerDetails/", siteId), request)


### PR DESCRIPTION
According to https://www.solaredge.com/sites/default/files/se_monitoring_api.pdf, the parameter is called "meters", not "meter".

Also fixed the README example along the way. Thanks for creating this!